### PR TITLE
🐛 main file was pointing to the source version

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "lifx-http-api",
   "version": "1.0.2",
   "description": "Thin wrapper around the Lifx HTTP API",
-  "main": "source/lifx.js",
+  "main": "dist/lifx.js",
   "scripts": {
     "prepublish": "npm run build",
     "build": "node_modules/.bin/babel source --presets babel-preset-es2015 --out-dir dist",


### PR DESCRIPTION
instead of pointing to the built version.

Now, requiring lifx-http-api will actually work.